### PR TITLE
Simplify pre-commit and commit-msg hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,3 +1,1 @@
-#!/usr/bin/env sh
-
 pnpm commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,1 @@
-#!/usr/bin/env sh
-
 pnpm lint-staged


### PR DESCRIPTION
- Remove shebang lines from both hooks
- Remove empty lines for cleaner scripts
- Ensure newline at end of pre-commit hook